### PR TITLE
Include js files in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include instant_rst/static/*.css
+include instant_rst/static/*.js
 include instant_rst/templates/*.html
 include instant_rst/templates/*.rst
 include scripts/instantRst


### PR DESCRIPTION
`instant_rst/static/main.js` was not being installed, meaning that the
templated html file was not able to be opened because the server would not find
`main.js`.