### PR TITLE
Pin flask-socketio to avoid breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['flask','docutils', 'pygments','flask-socketio'],
+    install_requires=['flask','docutils', 'pygments','flask-socketio<5'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
Ran into #24 and found, in my case, the failure was due to breaking changes in one of the unpinned decencies.

The log output was stating:
 * Running on http://127.0.0.1:5676/ (Press CTRL+C to quit)
127.0.0.1 - - [06/Apr/2021 18:00:58] "GET / HTTP/1.1" 200 -
The client is using an unsupported version of the Socket.IO or Engine.IO protocols (further occurrences of this error will be logged with level INFO)
127.0.0.1 - - [06/Apr/2021 18:00:58] "GET /socket.io/?EIO=3&transport=polling&t=NYfC_WD HTTP/1.1" 400 -

The [Flask-Socketio docs](https://flask-socketio.readthedocs.io/en/latest/)) state breaking changes in release 5.x. Taking the easy road and preventing flask-socketio 5.x fixed the problem for me. Perhaps a better fix would be to upgrade socketio and/or engineio to support 5.x but I'm not familiar with enough with the packages to know if it's worth the trouble.