### PR TITLE
socket.io version compatible with installed flask-socketIO

### DIFF
--- a/instant_rst/templates/index.html
+++ b/instant_rst/templates/index.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-<script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.js"></script>
 <script src="http://code.jquery.com/jquery-latest.min.js"></script>
 <link rel="stylesheet" href="/static/mars.css">
 </head>

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['flask','docutils', 'pygments','flask-socketio'],
+    install_requires=['flask>=2.1.1','docutils', 'pygments','flask-socketio>=5.1.1'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
The hardcoded version of socket.io is not compatible with Flask-SocketIO 5.x. and leads to the following error:

```
The client is using an unsupported version of the Socket.IO or Engine.IO protocols (further occurrences of this error will be logged with level INFO)
```
with python=3.8 and Flask-SocketIO==5.1.1

Using socket.io 4.x resolves this.